### PR TITLE
helm 支持通过配置文件新增模版

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
     cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
     echo "Asia/Shanghai" > /etc/timezone && \
     apk del tzdata && \
-    apk update && apk upgrade && apk add --no-cache sqlite-libs curl
+    apk update && apk upgrade && apk add --no-cache sqlite-libs curl sqlite
 
 HEALTHCHECK --start-period=10s --interval=20s --timeout=3s --retries=3 \
     CMD curl -fs http://localhost:8080/health || exit 1

--- a/example/helm/prometheusalert/config/init.sql
+++ b/example/helm/prometheusalert/config/init.sql
@@ -1,0 +1,3 @@
+INSERT INTO `prometheus_alert_d_b` VALUES ('50', 'wx', 'Prometheus', 'prometheus-wx-2', '{{ $var := .externalURL}}{{ range $k,$v:=.alerts }}\r\n{{if eq $v.status \"resolved\"}}\r\n[Prometheus恢复信息]($v.generatorURL}})\r\n>**[{{$v.labels.alertname}}]({{$var}})**\r\n>告警级别: {{$v.labels.level}}\r\n开始时间: {{$v.startsAt}}\r\n结束时间: {{$v.endsAt}}\r\n故障主机IP: {{$v.labels.instance}}\r\n**{{$v.annotations.description}}**\r\n{{else}}\r\n[Prometheus告警信息]($v.generatorURL}})\r\n>**[{{$v.labels.alertname}}]({{$var}})**\r\n>告警级别: {{$v.labels.level}}\r\n开始时间: {{$v.startsAt}}\r\n结束时间: {{$v.endsAt}}\r\n故障主机IP: {{$v.labels.instance}}\r\n**{{$v.annotations.description}}**\r\n{{end}}\r\n{{ end }}', '2020-12-22 03:07:19');
+
+

--- a/example/helm/prometheusalert/templates/deployment.yaml
+++ b/example/helm/prometheusalert/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ['sh', '-c', "sqlite3 /app/db/PrometheusAlertDB.db '.read /app/db/init.sql' && /app/PrometheusAlert"]
           env:
           - name: TZ
             value: "Asia/Shanghai"
@@ -34,6 +35,9 @@ spec:
           - name: prometheus-alert-center-conf
             mountPath: /app/user.csv
             subPath: user.csv
+          - name: prometheus-alert-center-conf
+            mountPath: /app/db/init.sql
+            subPath: init.sql
           livenessProbe:
             httpGet:
               path: /health
@@ -75,3 +79,5 @@ spec:
             path: app.conf
           - key: user.csv
             path: user.csv
+          - key: init.sql
+            path: init.sql

--- a/example/helm/prometheusalert/values.yaml
+++ b/example/helm/prometheusalert/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 image:
+  # 支持配置自定义模版需要重出镜像，或者使用本人构建镜像：lusson/prometheusalert:v1.0
   repository: feiyu563/prometheus-alert:latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
helm 部署时，通过 init.sql 在部署时自定义修改模版数据
需要基于 master 分支重出镜像，或者使用本人构建镜像：lusson/prometheusalert:v1.0