### PR TITLE
Webhook 增加http 请求的 contentType 配置

### DIFF
--- a/conf/app-example.conf
+++ b/conf/app-example.conf
@@ -75,6 +75,8 @@ wxurl=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxxx
 open-feishu=1
 #默认飞书机器人地址
 fsurl=https://open.feishu.cn/open-apis/bot/hook/xxxxxxxxx
+# webhook 发送 http 请求的 contentType, 如 application/json, application/x-www-form-urlencoded，不配置默认 application/json
+wh_contenttype=application/json
 
 #---------------------↓腾讯云接口-----------------------
 #是否开启腾讯云短信告警通道,可同时开始多个通道0为关闭,1为开启

--- a/controllers/WebTemplate.go
+++ b/controllers/WebTemplate.go
@@ -41,19 +41,22 @@ func (c *MainController) AddTpl() {
 		c.Redirect("/login", 302)
 		return
 	}
+
 	//获取表单信息
 	tid := c.Input().Get("id")
 	name := c.Input().Get("name")
 	t_tpye := c.Input().Get("type")
 	t_use := c.Input().Get("use")
 	content := c.Input().Get("content")
+	contentType := c.Input().Get("contentType")
+	fmt.Println(" ========== 修改, contentType", contentType)
 	var err error
 	if len(tid) == 0 {
 		id, _ := strconv.Atoi(tid)
-		err = models.AddTpl(id, name, t_tpye, t_use, content)
+		err = models.AddTpl(id, name, t_tpye, t_use, content, contentType)
 	} else {
 		id, _ := strconv.Atoi(tid)
-		err = models.UpdateTpl(id, name, t_tpye, t_use, content)
+		err = models.UpdateTpl(id, name, t_tpye, t_use, content, contentType)
 	}
 	var resp interface{}
 	if err != nil {
@@ -74,7 +77,7 @@ func (c *MainController) ImportTpl() {
 	if len(imTpl) > 0 {
 		var resp []string
 		for _, v := range imTpl {
-			err := models.AddTpl(v.Id, v.Tplname, v.Tpltype, v.Tpluse, v.Tpl)
+			err := models.AddTpl(v.Id, v.Tplname, v.Tpltype, v.Tpluse, v.Tpl, v.WebhookContentType)
 			var strs string
 			if err != nil {
 				strs = v.Tplname + "：" + err.Error() + "\n"
@@ -111,6 +114,7 @@ func (c *MainController) TemplateEdit() {
 		GlobalPrometheusAlertTpl, _ = models.GetAllTpl()
 	}
 	c.Data["Template"] = Template
+	c.Data["contentType"] = GetWebhookContentType(Template)
 	c.Data["IsLogin"] = CheckAccount(c.Ctx)
 }
 
@@ -127,4 +131,14 @@ func (c *MainController) TemplateDel() {
 		GlobalPrometheusAlertTpl, _ = models.GetAllTpl()
 	}
 	c.Redirect("/template", 302)
+}
+
+func GetWebhookContentType(tpl *models.PrometheusAlertDB) string {
+	if tpl.WebhookContentType != "" {
+		return tpl.WebhookContentType
+	} else if beego.AppConfig.String("wh_contenttype") != "" {
+		return beego.AppConfig.String("wh_contenttype")
+	} else {
+		return "application/json"
+	}
 }

--- a/controllers/WebTemplate.go
+++ b/controllers/WebTemplate.go
@@ -4,6 +4,7 @@ import (
 	"PrometheusAlert/models"
 	"encoding/json"
 	"github.com/astaxie/beego/logs"
+        "github.com/astaxie/beego"
 	"strconv"
 	"strings"
 )
@@ -49,7 +50,6 @@ func (c *MainController) AddTpl() {
 	t_use := c.Input().Get("use")
 	content := c.Input().Get("content")
 	contentType := c.Input().Get("contentType")
-	fmt.Println(" ========== 修改, contentType", contentType)
 	var err error
 	if len(tid) == 0 {
 		id, _ := strconv.Atoi(tid)

--- a/controllers/prometheusalert.go
+++ b/controllers/prometheusalert.go
@@ -58,21 +58,22 @@ type AliyunAlert struct {
 }
 
 type PrometheusAlertMsg struct {
-	Tpl        string
-	Type       string
-	Ddurl      string
-	Wxurl      string
-	Fsurl      string
-	Phone      string
-	WebHookUrl string
-	ToUser     string
-	Email      string
-	ToParty    string
-	ToTag      string
-	GroupId    string
-	AtSomeOne  string
-	RoundRobin string
-	Split      string
+	Tpl                string
+	Type               string
+	Ddurl              string
+	Wxurl              string
+	Fsurl              string
+	Phone              string
+	WebHookUrl         string
+	ToUser             string
+	Email              string
+	ToParty            string
+	ToTag              string
+	GroupId            string
+	AtSomeOne          string
+	RoundRobin         string
+	Split              string
+	WebhookContentType string
 }
 
 func (c *PrometheusAlertController) PrometheusAlert() {
@@ -124,6 +125,7 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 		pMsg.Fsurl = beego.AppConfig.String("fsurl")
 	}
 	pMsg.WebHookUrl = c.Input().Get("webhookurl")
+	pMsg.WebhookContentType = c.Input().Get("webhookContentType")
 	pMsg.Phone = c.Input().Get("phone")
 	if pMsg.Phone == "" && (pMsg.Type == "txdx" || pMsg.Type == "hwdx" || pMsg.Type == "bddx" || pMsg.Type == "alydx" || pMsg.Type == "txdh" || pMsg.Type == "alydh" || pMsg.Type == "rlydh" || pMsg.Type == "7moordx" || pMsg.Type == "7moordh") {
 		pMsg.Phone = GetUserPhone(1)
@@ -472,10 +474,10 @@ func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsig
 	case "webhook":
 		Fwebhookurl := strings.Split(pmsg.WebHookUrl, ",")
 		if pmsg.RoundRobin == "true" {
-			ReturnMsg += PostToWebhook(message, DoBalance(Fwebhookurl), logsign)
+			ReturnMsg += PostToWebhook(message, DoBalance(Fwebhookurl), logsign, pmsg.WebhookContentType)
 		} else {
 			for _, url := range Fwebhookurl {
-				ReturnMsg += PostToWebhook(message, url, logsign)
+				ReturnMsg += PostToWebhook(message, url, logsign, pmsg.WebhookContentType)
 			}
 		}
 

--- a/controllers/webhook.go
+++ b/controllers/webhook.go
@@ -4,14 +4,15 @@ import (
 	"PrometheusAlert/models"
 	"bytes"
 	"crypto/tls"
-	"github.com/astaxie/beego"
-	"github.com/astaxie/beego/logs"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/logs"
 )
 
-func PostToWebhook(text, WebhookUrl, logsign string) string {
+func PostToWebhook(text, WebhookUrl, logsign string, contentType string) string {
 	logs.Info(logsign, "[Webhook]", text)
 	JsonMsg := bytes.NewReader([]byte(text))
 	var tr *http.Transport
@@ -29,7 +30,10 @@ func PostToWebhook(text, WebhookUrl, logsign string) string {
 		}
 	}
 	client := &http.Client{Transport: tr}
-	res, err := client.Post(WebhookUrl, "application/json", JsonMsg)
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	res, err := client.Post(WebhookUrl, contentType, JsonMsg)
 	if err != nil {
 		logs.Error(logsign, "[Webhook]", err.Error())
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -2,18 +2,20 @@ package models
 
 import (
 	"errors"
-	"github.com/astaxie/beego/orm"
 	"time"
+
+	"github.com/astaxie/beego/orm"
 )
 
 // 分类
 type PrometheusAlertDB struct {
-	Id      int
-	Tpltype string //发送类型如钉钉、企业微信、飞书等
-	Tpluse  string //接受目标如Prometheus、WebHook、graylog
-	Tplname string `orm:"index"`
-	Tpl     string `orm:"type(text)"`
-	Created time.Time
+	Id                 int
+	Tpltype            string //发送类型如钉钉、企业微信、飞书等
+	Tpluse             string //接受目标如Prometheus、WebHook、graylog
+	Tplname            string `orm:"index"`
+	Tpl                string `orm:"type(text)"`
+	WebhookContentType string // webhook 请求的 contentType 如 application/json, application/x-www-form-urlencoded 等
+	Created            time.Time
 }
 
 func GetAllTpl() ([]*PrometheusAlertDB, error) {
@@ -64,7 +66,7 @@ func DelTpl(id int) error {
 	return err
 }
 
-func AddTpl(id int, tplname, t_type, t_use, tpl string) error {
+func AddTpl(id int, tplname, t_type, t_use, tpl string, contentType string) error {
 	o := orm.NewOrm()
 	qs := o.QueryTable("PrometheusAlertDB")
 	bExist := qs.Filter("Tplname", tplname).Exist()
@@ -74,19 +76,20 @@ func AddTpl(id int, tplname, t_type, t_use, tpl string) error {
 		return err
 	}
 	Template_table := &PrometheusAlertDB{
-		Id:      id,
-		Tplname: tplname,
-		Tpltype: t_type,
-		Tpluse:  t_use,
-		Tpl:     tpl,
-		Created: time.Now(),
+		Id:                 id,
+		Tplname:            tplname,
+		Tpltype:            t_type,
+		Tpluse:             t_use,
+		Tpl:                tpl,
+		WebhookContentType: contentType,
+		Created:            time.Now(),
 	}
 	// 插入数据
 	_, err = o.Insert(Template_table)
 	return err
 }
 
-func UpdateTpl(id int, tplname, t_type, t_use, tpl string) error {
+func UpdateTpl(id int, tplname, t_type, t_use, tpl string, contentType string) error {
 	o := orm.NewOrm()
 	tpl_update := &PrometheusAlertDB{Id: id}
 	err := o.Read(tpl_update)
@@ -96,6 +99,7 @@ func UpdateTpl(id int, tplname, t_type, t_use, tpl string) error {
 		tpl_update.Tpltype = t_type
 		tpl_update.Tpluse = t_use
 		tpl_update.Tpl = tpl
+		tpl_update.WebhookContentType = contentType
 		tpl_update.Created = time.Now()
 		_, err := o.Update(tpl_update)
 		return err

--- a/views/template_add.html
+++ b/views/template_add.html
@@ -86,6 +86,11 @@
 					<option value="voice">语音播报</option>
 					<option value="fsapp">飞书机器人应用</option>
 					</select>
+                    <label id="contentTypeLabel" style="display: none;">请求的content-type</label>
+                    <select class="form-control" id="contentType" name="contentType" style="display: none;">
+                        <option value="application/json" selected="selected">application/json</option>
+					    <option value="application/x-www-form-urlencoded">application/x-www-form-urlencoded</option>
+                    </select>
 				  </div>
 				</div>
 				<div class="col-sm-6">
@@ -206,60 +211,80 @@ function typeChange(){
 	document.getElementById("Pat").style.display="";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="wx"){
 	typeStr.innerText="微信机器人地址";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="fs"){
 	typeStr.innerText="飞书机器人地址";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="fsapp"){
 	typeStr.innerText="飞书 用户open_id、user_id、union_ids、部门open_department_id";
 	document.getElementById("Purl").style.display="none";
 	document.getElementById("Pat").style.display="";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="voice"){
 	typeStr.innerText="";
 	document.getElementById("Purl").style.display="none";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="webhook"){
 	typeStr.innerText="WebHook地址";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="";
+    document.getElementById("contentType").style.display="";
  } else if(typeSelect=="email"){
 	typeStr.innerText="邮箱(多个请以,隔开)";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="rl"){
 	typeStr.innerText="百度Hi(如流)群id";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else if(typeSelect=="workwechat"){
 	typeStr.innerText="接受用户";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="";
 	document.getElementById("Tag").style.display="";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  } else{
 	typeStr.innerText="手机号";
 	document.getElementById("Purl").style.display="";
 	document.getElementById("Pat").style.display="none";
 	document.getElementById("Party").style.display="none";
 	document.getElementById("Tag").style.display="none";
+    document.getElementById("contentTypeLabel").style.display="none";
+    document.getElementById("contentType").style.display="none";
  }
  
 }
@@ -301,6 +326,7 @@ function sendtest(){
 	var upat=document.getElementById("pat");
 	var upparty=document.getElementById("pparty");
 	var uptag=document.getElementById("ptag");
+    // var webhookContentType=document.;
 	var sendurl="";
 	if (utype.value=="dd"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&ddurl='+upurl.value+'&at='+upat.value;
@@ -311,7 +337,7 @@ function sendtest(){
 	} else if(utype.value=="fsapp"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&at='+upat.value;
 	} else if(utype.value=="webhook"){
-	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value;
+	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value+'&webhookContentType=??';
 	} else if(utype.value=="email"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&email='+upurl.value;
 	} else if(utype.value=="rl"){

--- a/views/template_add.html
+++ b/views/template_add.html
@@ -326,7 +326,7 @@ function sendtest(){
 	var upat=document.getElementById("pat");
 	var upparty=document.getElementById("pparty");
 	var uptag=document.getElementById("ptag");
-    // var webhookContentType=document.;
+	var ucontentType=document.getElementById("contentType")
 	var sendurl="";
 	if (utype.value=="dd"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&ddurl='+upurl.value+'&at='+upat.value;
@@ -337,7 +337,7 @@ function sendtest(){
 	} else if(utype.value=="fsapp"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&at='+upat.value;
 	} else if(utype.value=="webhook"){
-	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value+'&webhookContentType=??';
+	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value+'&webhookContentType='+ucontentType.value;
 	} else if(utype.value=="email"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&email='+upurl.value;
 	} else if(utype.value=="rl"){

--- a/views/template_edit.html
+++ b/views/template_edit.html
@@ -89,6 +89,13 @@
 					<option value="voice" {{if eq .Template.Tpltype "voice"}}selected="selected"{{end}}>语音播报</option>
 					<option value="fsapp" {{if eq .Template.Tpltype "fsapp"}}selected="selected"{{end}}>飞书机器人应用</option>
 					</select>
+                    {{if eq .Template.Tpltype "webhook"}}
+                    <label>请求的content-type</label>
+                    <select class="form-control" id="contentType" name="contentType">
+                        <option value="application/json" {{if eq .contentType "application/json"}}selected="selected"{{end}}>application/json</option>
+					    <option value="application/x-www-form-urlencoded" {{if eq .contentType "application/x-www-form-urlencoded"}}selected="selected"{{end}}>application/x-www-form-urlencoded</option>
+                    </select>
+                    {{end}}
 				  </div>
 				</div>
 				

--- a/views/template_edit.html
+++ b/views/template_edit.html
@@ -317,6 +317,7 @@ function sendtest(){
 	var upparty=document.getElementById("pparty");
 	var uptag=document.getElementById("ptag");
 	var upgroupid=document.getElementById("pgroupid");
+	var ucontentType = document.getElementById('contentType')
 	var sendurl="";
 	if (utype.value=="dd"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&ddurl='+upurl.value+'&at='+upat.value;
@@ -327,7 +328,7 @@ function sendtest(){
 	} else if(utype.value=="fsapp"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&at='+upat.value;
 	} else if(utype.value=="webhook"){
-	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value;
+	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&webhookurl='+upurl.value+'&webhookContentType='+ucontentType.value;
 	} else if(utype.value=="email"){
 	   sendurl='{{ urlfor "PrometheusAlertController.PrometheusAlert"}}?type='+utype.value+'&tpl='+uname.value+'&email='+upurl.value;
 	} else if(utype.value=="rl"){


### PR DESCRIPTION
1.添加和修改模版时，选择类型时 webhook，会展示 contentType 下拉选项卡，点击保存会存到数据库
![prometheus-alert1](https://user-images.githubusercontent.com/19859400/202000264-ad23b137-b8a6-43b7-85d0-61dc40e689b3.png)

2.配置添加 wh_contenttype=application/json，当 webhook 没有配置contentType 时，使用 wh_contenttype 配置的值
3.数据库表 PrometheusAlertDB 添加字段 WebhookContentType
4. form 表单发送格式使用param1=a&param2=b 形式的告警模版

测试
1.form 表单提交
<img width="1087" alt="图片2" src="https://user-images.githubusercontent.com/19859400/202000462-1a3f7205-2c3e-4e91-961f-abdca0d1ec43.png">
<img width="991" alt="图片3" src="https://user-images.githubusercontent.com/19859400/202000547-b8b15799-7917-4946-b84f-e2a111d02111.png">

2.json 提交
<img width="1092" alt="图片4" src="https://user-images.githubusercontent.com/19859400/202000702-8ca277c1-91b7-4421-91c9-81c2d5038fd5.png">
<img width="892" alt="图片5" src="https://user-images.githubusercontent.com/19859400/202000780-729cf279-33e1-4f56-acff-8bc482f7fea5.png">
