### PR TITLE
fix feishu api v2 can't @user with email. 

### DIFF
--- a/controllers/feishu.go
+++ b/controllers/feishu.go
@@ -135,7 +135,7 @@ func PostToFeiShuv2(title, text, Fsurl, userOpenId, logsign string) string {
 		OpenIds := strings.Split(userOpenId, ",")
 		OpenIdtext := ""
 		for _, OpenId := range OpenIds {
-			OpenIdtext += "<at user_id=" + OpenId + " id=" + OpenId + "></at>"
+			OpenIdtext += "<at user_id=" + OpenId + " id=" + OpenId + " email=" + OpenId  + "></at>"
 		}
 		SendContent += OpenIdtext
 	}


### PR DESCRIPTION
#357 添加email属性解决飞书机器人卡片消息不能通过email @用户