### PR TITLE
fix: 关于自定义模板通过 URL 传递钉钉加签错误

### DIFF
--- a/doc/readme/conf-dingding.md
+++ b/doc/readme/conf-dingding.md
@@ -66,7 +66,15 @@
 
 如果配置文件中启用了钉钉加签认证，但 webhook url 并没有传递 parm secret，那么程序将返回不加签的地址。也就是说，PrometheusAlert 配置中启用钉钉加签并不会影响不加签的机器人。
 
-示例如下：
+[issue:363](https://github.com/feiyu563/PrometheusAlert/issues/363) 关于自定义模板使用 URL 传递 ddurl 和签名报错，需要修改使用方法。
+
+在自定义模板 URL 参数的 ddurl 里面可能有多个地址，有的加签，有的不加签。因此代码不太好处理，暂时没有解决。建议使用告警组或将 `&` 符号替换为 `%26` 编码。
+
+默认模板、配置文件和使用告警组的钉钉加签是正常的。
+
+<br/>
+
+配置文件传递地址示例如下：
 
 ```conf
 # 默认的钉钉机器人地址 webhook url 格式
@@ -76,12 +84,31 @@ https://oapi.dingtalk.com/robot/send?access_token=XXX
 # 带上加签参数: secret=mysecret
 https://oapi.dingtalk.com/robot/send?access_token=XXX&secret=mysecret
 
-# 程序加签处理后生成的加签地址
-https://oapi.dingtalk.com/robot/send?access_token=XXXXXX&timestamp=XXX&sign=XXX
+# 程序加签处理后生成的加签地址: https://oapi.dingtalk.com/robot/send?access_token=XXXXXX&timestamp=XXX&sign=XXX
 
 # 如果配置文件中启用了钉钉加签认证，但 webhook url 并没有传递 parm secret，那么程序将返回不加签的地址
 https://oapi.dingtalk.com/robot/send?access_token=XXX
 ```
+
+<br/>
+
+自定义模板 URL 参数传递地址配置如下:
+
+```conf
+# 使用告警组配置地址
+http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&alertgroup=xxx&at=xxx
+
+# 需要把 & 特殊字符转义为 %26 编码字符
+# 单个地址
+http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=加签地址%26secret=xxx&at=xxx
+
+# 多个地址
+http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=加签地址%26secret=xxx,加签地址%26secret=xxx
+
+# 混合加签和不加签地址
+http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=不加签地址,加签地址%26secret=xxx
+```
+
 
 <br/>
 <br/>


### PR DESCRIPTION
issue: <https://github.com/feiyu563/PrometheusAlert/issues/363>

关于自定义模板通过 URL 传递钉钉加签错误，更新了钉钉加签使用文档。