### PR TITLE
fix(prometheusalert): 请求/prometheusalert接口，请求body不合法时返回详细报错，而非空字符串

### DIFF
--- a/controllers/prometheusalert.go
+++ b/controllers/prometheusalert.go
@@ -80,6 +80,7 @@ type PrometheusAlertMsg struct {
 
 func (c *PrometheusAlertController) PrometheusAlert() {
 	logsign := "[" + LogsSign() + "]"
+	var message string
 	var p_json interface{}
 	//针对prometheus的消息特殊处理
 	p_alertmanager_json := make(map[string]interface{})
@@ -107,7 +108,11 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 		AliyunAlertJson.Timestamp = c.Input().Get("timestamp")
 		p_json = AliyunAlertJson
 	} else {
-		json.Unmarshal(c.Ctx.Input.RequestBody, &p_json)
+		err := json.Unmarshal(c.Ctx.Input.RequestBody, &p_json)
+		if err != nil {
+			message = "请求body不是合法json."
+			logs.Error(logsign, message)
+		}
 		//针对prometheus的消息特殊处理
 		json.Unmarshal(c.Ctx.Input.RequestBody, &p_alertmanager_json)
 	}
@@ -161,7 +166,6 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 		}
 	}
 
-	var message string
 	if pMsg.Type != "" && PrometheusAlertTpl != nil {
 		//判断是否是来自 Prometheus的告警
 		if pMsg.Split != "false" && PrometheusAlertTpl.Tpluse == "Prometheus" {


### PR DESCRIPTION
用postman发送请求测试，一直返回200状态码，但是webhook收不到消息，日志没报错，响应body只有空字符串，唉