### PR TITLE
feat: 新增钉钉、飞书告警消息的预览文字配置，使用告警标题作为预览文本，代替原有的 PrometheusAlert 固定词

### DIFF
--- a/controllers/prometheusalert.go
+++ b/controllers/prometheusalert.go
@@ -76,6 +76,8 @@ type PrometheusAlertMsg struct {
 	RoundRobin         string
 	Split              string
 	WebhookContentType string
+	UseAlertName       string // 使用告警名称作为告警消息的预览词
+	AlertName          string // 告警标题名称
 }
 
 func (c *PrometheusAlertController) PrometheusAlert() {
@@ -149,6 +151,7 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 	pMsg.RoundRobin = c.Input().Get("rr")
 	//该配置仅适用于alertmanager的消息,用于判断是否需要拆分alertmanager告警消息
 	pMsg.Split = c.Input().Get("split")
+	pMsg.UseAlertName = c.Input().Get("usealertname")
 
 	//模版加载进内存处理,防止告警过多频繁查库
 	var PrometheusAlertTpl *models.PrometheusAlertDB
@@ -181,6 +184,14 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 				go SetRecord(AlertValue)
 				//提取 prometheus 告警消息中的 label，用于和告警路由比对
 				xalert := AlertValue.(map[string]interface{})
+
+				if pMsg.UseAlertName == "true" {
+					// 获取告警名称
+					pMsg.AlertName = xalert["labels"].(map[string]interface{})["alertname"].(string)
+				} else {
+					pMsg.AlertName = beego.AppConfig.String("title")
+				}
+
 				//路由处理,可能存在多个路由都匹配成功，所以这里返回的是个列表sMsg
 				Return_pMsgs := AlertRouterSet(xalert, pMsg, PrometheusAlertTpl.Tpl)
 				for _, Return_pMsg := range Return_pMsgs {
@@ -201,6 +212,16 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 
 			}
 		} else {
+			if pMsg.UseAlertName == "true" {
+				// 获取告警名称，以第一个告警名称作为消息提示信息
+				Alerts_Value := p_alertmanager_json["alerts"].([]interface{})
+				if len(Alerts_Value) > 0 {
+					pMsg.AlertName = Alerts_Value[0].(map[string]interface{})["labels"].(map[string]interface{})["alertname"].(string)
+				}
+			} else {
+				pMsg.AlertName = beego.AppConfig.String("title")
+			}
+
 			//获取渲染后的模版
 			err, msg := TransformAlertMessage(p_json, PrometheusAlertTpl.Tpl)
 
@@ -444,7 +465,10 @@ func TransformAlertMessage(p_json interface{}, tpltext string) (error error, msg
 
 // 发送消息
 func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsign string) string {
-	Title := beego.AppConfig.String("title")
+	// Title := beego.AppConfig.String("title")
+	// 获取告警名称
+	alertName := pmsg.AlertName
+	fmt.Printf("alertName: %s\n", alertName)
 	var ReturnMsg string
 	models.AlertsFromCounter.WithLabelValues("/prometheusalert").Add(1)
 	ChartsJson.Prometheusalert += 1
@@ -464,10 +488,10 @@ func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsig
 	case "dd":
 		Ddurl := strings.Split(pmsg.Ddurl, ",")
 		if pmsg.RoundRobin == "true" {
-			ReturnMsg += PostToDingDing(Title, message, DoBalance(Ddurl), pmsg.AtSomeOne, logsign)
+			ReturnMsg += PostToDingDing(alertName, message, DoBalance(Ddurl), pmsg.AtSomeOne, logsign)
 		} else {
 			for _, url := range Ddurl {
-				ReturnMsg += PostToDingDing(Title, message, url, pmsg.AtSomeOne, logsign)
+				ReturnMsg += PostToDingDing(alertName, message, url, pmsg.AtSomeOne, logsign)
 			}
 		}
 
@@ -475,10 +499,10 @@ func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsig
 	case "fs":
 		Fsurl := strings.Split(pmsg.Fsurl, ",")
 		if pmsg.RoundRobin == "true" {
-			ReturnMsg += PostToFS(Title, message, DoBalance(Fsurl), pmsg.AtSomeOne, logsign)
+			ReturnMsg += PostToFS(alertName, message, DoBalance(Fsurl), pmsg.AtSomeOne, logsign)
 		} else {
 			for _, url := range Fsurl {
-				ReturnMsg += PostToFS(Title, message, url, pmsg.AtSomeOne, logsign)
+				ReturnMsg += PostToFS(alertName, message, url, pmsg.AtSomeOne, logsign)
 			}
 		}
 
@@ -540,7 +564,7 @@ func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsig
 		ReturnMsg += SendVoice(message, logsign)
 	//飞书APP渠道
 	case "fsapp":
-		ReturnMsg += PostToFeiShuApp(Title, message, pmsg.AtSomeOne, logsign)
+		ReturnMsg += PostToFeiShuApp(alertName, message, pmsg.AtSomeOne, logsign)
 	//kafka渠道
 	case "kafka":
 		ReturnMsg += SendKafka(message, logsign)

--- a/controllers/prometheusalert.go
+++ b/controllers/prometheusalert.go
@@ -213,10 +213,10 @@ func (c *PrometheusAlertController) PrometheusAlert() {
 			}
 		} else {
 			if pMsg.UseAlertName == "true" {
-				// 获取告警名称，以第一个告警名称作为消息提示信息
-				Alerts_Value := p_alertmanager_json["alerts"].([]interface{})
-				if len(Alerts_Value) > 0 {
-					pMsg.AlertName = Alerts_Value[0].(map[string]interface{})["labels"].(map[string]interface{})["alertname"].(string)
+				// 获取告警名称，以第一个告警名称作为消息的预览文字
+				AlertsValue := p_alertmanager_json["alerts"].([]interface{})
+				if len(AlertsValue) > 0 {
+					pMsg.AlertName = AlertsValue[0].(map[string]interface{})["labels"].(map[string]interface{})["alertname"].(string)
 				}
 			} else {
 				pMsg.AlertName = beego.AppConfig.String("title")
@@ -468,7 +468,6 @@ func SendMessagePrometheusAlert(message string, pmsg *PrometheusAlertMsg, logsig
 	// Title := beego.AppConfig.String("title")
 	// 获取告警名称
 	alertName := pmsg.AlertName
-	fmt.Printf("alertName: %s\n", alertName)
 	var ReturnMsg string
 	models.AlertsFromCounter.WithLabelValues("/prometheusalert").Add(1)
 	ChartsJson.Prometheusalert += 1

--- a/doc/readme/conf-dingding.md
+++ b/doc/readme/conf-dingding.md
@@ -2,7 +2,7 @@
 
 ## 开启钉钉机器人
 
-打开钉钉,进入钉钉群中,选择群设置-->智能群助手-->添加机器人-->自定义，可参下图：
+打开钉钉,进入钉钉群中,选择`群设置`-->`智能群助手`-->`添加机器人`-->`自定义`，可参下图：
 
 ![ding](../images/dingding1.png)
 
@@ -24,7 +24,7 @@
 
 ![ding4](../images/dingding5.png)
 
-钉钉目前支持只支持markdown语法的子集，具体支持的元素如下：
+钉钉目前支持只支持 `markdown` 语法的子集，具体支持的元素如下：
 
 ```md
 标题
@@ -56,6 +56,7 @@
 1. item1
 2. item2
 ```
+钉钉官方文档：https://open.dingtalk.com/document/dingstart/custom-bot-send-message-type
 
 <br/>
 <br/>
@@ -70,9 +71,9 @@
 
 如果配置文件中启用了钉钉加签认证，但 webhook url 并没有传递 parm secret，那么程序将返回不加签的地址。也就是说，PrometheusAlert 配置中启用钉钉加签并不会影响不加签的机器人。
 
-[issue:363](https://github.com/feiyu563/PrometheusAlert/issues/363) 关于自定义模板使用 URL 传递 ddurl 和签名报错，需要修改使用方法。
+[issue:363](https://github.com/feiyu563/PrometheusAlert/issues/363) 关于自定义模板使用 URL 传递 `ddurl` 和签名报错，需要修改使用方法。
 
-在自定义模板 URL 参数的 ddurl 里面可能有多个地址，有的加签，有的不加签。因此代码不太好处理，暂时没有解决。建议使用告警组或将 `&` 符号替换为 `%26` 编码。
+在自定义模板 URL 参数的 `ddurl` 里面可能有多个地址，有的加签，有的不加签。因此代码不太好处理，暂时没有解决。建议使用告警组或将 `&` 符号替换为 `%26` 编码。
 
 默认模板、配置文件和使用告警组的钉钉加签是正常的。
 
@@ -95,12 +96,34 @@ https://oapi.dingtalk.com/robot/send?access_token=XXX
 ```
 
 <br/>
+告警组配置示例：
+
+```conf
+## app.conf
+...
+# ---------------------↓告警组-----------------------                     
+# 有其他新增的配置段，请放在告警组的上面                                 
+# 暂时仅针对 PrometheusContronller 中的 /prometheus/alert 路由           
+# 告警组如果放在了 wx, dd... 那部分的上分，beego section 取 url 值不太对。
+# 所以这里使用 include 来包含另告警组配置                                
+# 是否启用告警组功能                                                     
+open-alertgroup=1                                                        
+
+[ag-alert]                                                                                                                                                                                         
+ddurl=https://oapi.dingtalk.com/robot/send?access_token=435xxx&secret=SECxxx
+
+[ag-low-level]                                                                                                                                                                                     
+ddurl=https://oapi.dingtalk.com/robot/send?access_token=bf1xxx&secret=SECxxx
+
+[ag-biz-alert]                                                                                                                                                                                     
+ddurl=https://oapi.dingtalk.com/robot/send?access_token=b9cxxx&secret=SECxxx
+```
 
 自定义模板 URL 参数传递地址配置如下:
 
 ```conf
-# 使用告警组配置地址
-http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&alertgroup=xxx&at=xxx
+# 使用告警组配置地址，使用告警组组名
+http://prometheusalert:8080/prometheusalert?type=dd&tpl=prometheus-dd&alertgroup=alert&at=xxx
 
 # 需要把 & 特殊字符转义为 %26 编码字符
 # 单个地址

--- a/doc/readme/system-var.md
+++ b/doc/readme/system-var.md
@@ -1,37 +1,65 @@
 # 自定义模版参数说明
 ----------------------------------------------------------------------
 
-#### 1.钉钉机器人、企业微信机器人均已经支持@某人的功能。使用时，需要在Url中加入`&at= 1539510xxxx`；如需添加多个@目标，用,号分割即可。此处需注意：钉钉@使用的是手机号码，企业微信机器人@使用的是用户帐号。
+#### 1.钉钉机器人、企业微信机器人均已经支持@某人的功能。使用时，需要在Url中加入`&at=1539510xxxx`；如需添加多个 `@` 目标，用`,`号分隔即可。
+> 此处需注意：钉钉@使用的是**手机号码**，企业微信机器人@使用的是**用户帐号**。
 
-`示例：http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx&at= 1539510xxxx`
+示例：
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx&at=1539510xxxx
+```
 
 
 #### 2.url参数中 `ddurl、wxurl、fsurl、phone、email、wxuser、wxparty、wxtag、groupid `等可不写，如不写这些参数，则会默认去读取配置文件中的对应参数发送消息。
 
-`示例：http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd`
+示例：
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd
+```
 
 
-#### 3.url参数中支持参数 `rr=true`， 该参数为开启随机轮询，目前仅针对ddurl，fsurl，wxurl有效，默认情况下如果上述Url配置的是多个地址，则多个地址全部发送，如开启该选项，则从多个地址中随机取一个地址发送，主要是为了避免消息发送频率过高导致触发部分机器人拦截消息。
+#### 3.url参数中支持参数 `rr=true`， 该参数为开启随机轮询，目前仅针对 `ddurl`，`fsurl`，`wxurl` 有效，默认情况下如果上述Url配置的是多个地址，则多个地址全部发送，如开启该选项，则从多个地址中随机取一个地址发送，主要是为了避免消息发送频率过高导致触发部分机器人拦截消息。
 
-`示例：http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx&rr=true`
-
-
-#### 4.url参数新增 `split=true`，该参数仅针对Prometheus告警消息有效，作用是将Prometheus分组消息拆分成单条发送。默认开启，如果Prometheus一次告警附带的同分组的告警消息条数过多，可能会导致告警消息体过大。如需关闭请在url中加入split=false
-
-注意：此参数如设置为`split=false`，则PrometheusAlert web页面的路由和告警记录等功能将自动关闭，请谨慎。
-
-`示例：http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx&rr=true&split=false`
+示例：
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx&rr=true
+```
 
 
-#### 5.url参数新增 `emailtitle=运维监控中心`，该参数仅针对email有效，作用是替换app.conf中的Email_title邮件标题配置，实现动态定义邮件标题
+#### 4.url参数新增 `split=true`，该参数仅针对Prometheus告警消息有效，作用是将Prometheus分组消息拆分成单条发送。默认开启，如果Prometheus一次告警附带的同分组的告警消息条数过多，可能会导致告警消息体过大。如需关闭请在url中加入 `split=false`
 
-注意：此参数如设置为`split=false`，则PrometheusAlert web页面的路由和告警记录等功能将自动关闭，请谨慎。
+> 注意：此参数如设置为`split=false`，则PrometheusAlert web页面的**路由**和**告警记录**等功能将自动关闭，请谨慎。
 
-`示例：http://[prometheusalert_url]:8080/prometheusalert?type=email&tpl=prometheus-email&email=xxxx@xxx.com&emailtitle=运维监控中心`
+示例：
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&ddurl=https://oapi.dingtalk.com/robot/send?access_token=xxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx,https://oapi.dingtalk.com/robot/send?access_token=xxxxxx&rr=true&split=false
+```
 
 
-#### 6.自定义模板使用的是go语言的template模版，可以参考默认模版的一些语法来进行自定义。
+#### 5.url参数新增 `emailtitle=运维监控中心`，该参数仅针对email有效，作用是替换app.conf中的 `Email_title` 邮件标题配置，实现动态定义邮件标题
+
+> 注意：此参数如设置为`split=false`，则PrometheusAlert web页面的**路由**和**告警记录**等功能将自动关闭，请谨慎。
+
+示例：
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=email&tpl=prometheus-email&email=xxxx@xxx.com&emailtitle=运维监控中心
+```
+
+
+#### 6.自定义模板使用的是go语言的 `template` 模版，可以参考默认模版的一些语法来进行自定义。
+Issue： [通用自定义模版专用：欢迎共享大家的自定义模版，方便其他人也可以直接使用 #30](https://github.com/feiyu563/PrometheusAlert/issues/30) 
+ 有大家共享的自定义模板配置，可以参考。
 
 #### 7.模版数据等信息均存储在程序目录的下的`db/PrometheusAlertDB.db`中。
 
-#### 8.关于优先级问题：路由功能 > URL参数 > app.conf
+#### 8.关于优先级问题：路由功能 > URL参数 > `app.conf`
+
+#### 9. url 参数中新增有 `usealertname=true` 参数，用于使用 `AlertName` 作为渠道通知的消息预览文字
+默认情况下告警消息的预览文字为 `PrometheusAlert` 固定值，利用此参数可以将**告警名称**作为预览文字显示在未读消息中。
+```shell
+http://[prometheusalert_url]:8080/prometheusalert?type=dd&tpl=prometheus-dd&usealertname=true
+```
+
+该特性适用于如下渠道：
+- [x] dingding(钉钉)
+- [x] feishu(飞书)

--- a/doc/readme/system-webhook.md
+++ b/doc/readme/system-webhook.md
@@ -21,7 +21,7 @@ PrometheusAlert WebHook是实现将PrometheusAlert收到的消息转发给除了
 }
 ```
 
-- 如果我们需要将PrometheusAlert接收到的Prometheus发过来的告警转发到该接口，且需要满足该接口的json协议，则需要先在PrometheusAlert自定义模板页面新建一个WebHook的模版。模板的内容参考如下：
+- 如果我们需要将PrometheusAlert接收到的Prometheus发过来的告警转发到该接口，且需要满足该接口的`json`协议，则需要先在PrometheusAlert自定义模板页面新建一个WebHook的模版。模板的内容参考如下：
 ```
 {
 	"receiver": "{{.receiver}}",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module PrometheusAlert
 
-go 1.20
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/IBM/sarama v1.43.2


### PR DESCRIPTION
# 新功能
- url 参数新增 `usealertname=true` 配置，可用于开启 `AlertName` 告警名称作为未读消息的预览文本。

# 优化项
- `doc/readme/system-var.md` 说明文档中新增新参数的使用介绍。
- 优化部分配置使用说明文档。